### PR TITLE
Add removedBy field to track which user removed a document

### DIFF
--- a/lib/behavior/behavior.js
+++ b/lib/behavior/behavior.js
@@ -42,6 +42,13 @@ Behavior.create({
       };
     }
 
+    if (behavior.options.hasRemovedByField) {
+      definition.fields[behavior.options.removedByFieldName] = {
+        type: String,
+        optional: true
+      };
+    }
+
     return definition;
   },
   apply(Class) {

--- a/lib/utils/document_soft_remove.js
+++ b/lib/utils/document_soft_remove.js
@@ -43,6 +43,9 @@ function documentSoftRemove(args = {}) {
   if (behavior.options.hasRemovedAtField) {
     modifier.$set[behavior.options.removedAtFieldName] = new Date();
   }
+  if (behavior.options.hasRemovedByField) {
+    modifier.$set[behavior.options.removedByFieldName] = Meteor.userId();
+  }
   // Remove a document.
   const result = Collection._collection.update(selector, modifier);
 


### PR DESCRIPTION
This PR contains changes that enables users to track which user has soft-removed a document. The new field is not set by default, so the default behavior is not changed.
