### PR TITLE
Support `lazy: true`

### DIFF
--- a/package.js
+++ b/package.js
@@ -18,5 +18,5 @@ Package.onUse(function(api) {
     'jagi:astronomy@2.3.4'
   ], ['client', 'server']);
 
-  api.mainModule('lib/main.js', ['client', 'server']);
+  api.mainModule('lib/main.js', ['client', 'server'], { lazy: true });
 });


### PR DESCRIPTION
Due to the lack of this, astronomy's `lazy: true` has no effect on client bundles.